### PR TITLE
fixed a bug caused by multiprocessing

### DIFF
--- a/ParallelTVGL.py
+++ b/ParallelTVGL.py
@@ -154,6 +154,7 @@ class ParallelTVGL(BaseGraphicalLasso):
         if self.processes > self.blocks:
             self.processes = self.blocks
         self.chunk = int(np.round(self.blocks/float(self.processes)))
+        self.manager = Manager()
 
     def init_algorithm(self):
 
@@ -162,7 +163,7 @@ class ParallelTVGL(BaseGraphicalLasso):
         self.results = JoinableQueue()
         self.pipes = [Pipe() for i in range(self.processes-1)]
         self.procs = []
-        stopping_criteria = Manager().list()
+        stopping_criteria = self.manager.list()
         for i in range(self.processes):
             stopping_criteria.append(False)
 


### PR DESCRIPTION
When the parallelized version was running on my environment (macOS 13, python 2.7), it raised an exception:

```
Traceback (most recent call last):
  File "ParallelTVGL.py", line 127, in mp_parallel_tvgl
    if all(criteria is True for criteria in stopping_criteria):
  File "ParallelTVGL.py", line 127, in <genexpr>
    if all(criteria is True for criteria in stopping_criteria):
  File "<string>", line 2, in __getitem__
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/multiprocessing/managers.py", line 755, in _callmethod
    self._connect()
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/multiprocessing/managers.py", line 742, in _connect
    conn = self._Client(self._token.address, authkey=self._authkey)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/multiprocessing/connection.py", line 169, in Client
    c = SocketClient(address)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/multiprocessing/connection.py", line 308, in SocketClient
    s.connect(address)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/socket.py", line 228, in meth
    return getattr(self._sock,name)(*args)
error: [Errno 2] No such file or directory
```

This was caused by accessing cross process variables after the manager closed.

It could be explained by this post:
https://stackoverflow.com/questions/29702157/python-multiprocessing-manager-list-error-errno-2-no-such-file-or-directory